### PR TITLE
Feature/18s - Simplify svg setup

### DIFF
--- a/.changeset/18s-simplify-svg-setup.md
+++ b/.changeset/18s-simplify-svg-setup.md
@@ -1,0 +1,18 @@
+---
+issue: Simplify SVG setup for js/ts #18
+type: major
+---
+
+Now the default SVG setup will emit
+
+```javascript
+import starUrl, { ReactComponent as Star } from "./star.svg";
+```
+
+instead of
+
+```javascript
+import Star from "./star.svg";
+```
+
+as that's a better option here.

--- a/.changeset/18s-simplify-svg-setup.md
+++ b/.changeset/18s-simplify-svg-setup.md
@@ -1,5 +1,5 @@
 ---
-issue: Simplify SVG setup for js/ts #18
+issue: https://github.com/pmedianetwork/webpack-config/issues/18
 type: major
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,11 @@ function loadImages(
   options: FileLoaderOptions = {},
   // Resolve @svgr/webpack by an absolute path to avoid installing it
   // at consumers. #13
-  svgLoader = require.resolve("@svgr/webpack"),
+  //
+  // This uses svgr to emit React components. You'll get
+  // import starUrl, { ReactComponent as Star } from './star.svg'
+  // style of import from this by default.
+  svgLoader = [require.resolve("@svgr/webpack"), "url-loader"],
 ): webpack.Configuration {
   return {
     module: {


### PR DESCRIPTION
---
Closes #18

Since it's a major change (potentially breaking), we might as well separate the SVG bit into `loadSVG` and leave rest of the formats to `loadImages`.

---

**How to test (feature)**

**How to test (potential regressions)**
