### PR TITLE
chore: Update react-refresh-webpack-plugin

### DIFF
--- a/.changeset/28s-update-rfr.md
+++ b/.changeset/28s-update-rfr.md
@@ -1,0 +1,6 @@
+---
+issue: https://github.com/pmedianetwork/webpack-config/issues/28
+type: patch
+---
+
+react-refresh-webpack-plugin is using beta10 version now. This fixes the interoperability with webpack-plugin-serve and lets us use the two together in a configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,14 +1886,13 @@
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.4.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.0-beta.8.tgz",
-      "integrity": "sha512-MMdSFLGhWvPwNsOkPWUEaZwSZEgH+Ingl5sOxm1iv9WOb6AbVepAvSH79xArZosB3Pv6NWHj9ufU4dpwgluK/A==",
+      "version": "0.4.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.0-beta.10.tgz",
+      "integrity": "sha512-yhshasySVdNNPJOLUd0CR+4dCQCIpdGDRNDipJSmD/ioJcEUln5ghSfTTpe1+PvpOuQc5w3bOOObo1hcQaoCkg==",
       "requires": {
         "ansi-html": "^0.0.7",
         "error-stack-parser": "^2.0.6",
         "html-entities": "^1.2.1",
-        "lodash.debounce": "^4.0.8",
         "native-url": "^0.2.6",
         "schema-utils": "^2.6.5",
         "source-map": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.9.4",
     "@packtracker/webpack-plugin": "^2.2.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.0-beta.8",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.0-beta.10",
     "@sentry/webpack-plugin": "^1.10.0",
     "@svgr/webpack": "^5.4.0",
     "@types/brotli-webpack-plugin": "^1.1.0",


### PR DESCRIPTION
Closes #28.

**How to test (feature)**

If needed, I can add a small test to `demo/` for this. I tested beta10 outside of this project within react-refresh-webpack-plugin independently to verify their fix works.

**How to test (potential regressions)**
