### PR TITLE
chore: Make `waitForBuild` enabled by default on `webpackPluginServe`

### DIFF
--- a/.changeset/wait-for-build.md
+++ b/.changeset/wait-for-build.md
@@ -1,0 +1,6 @@
+---
+issue: https://github.com/pmedianetwork/webpack-config/issues/37
+type: patch
+---
+
+Make `webpackPluginServe` to use `waitForBuild` by default. The setting is particulary useful for projects like **adverity-presense-frontend** where webpack is used as the frontend. Otherwise it might serve HTML before the initial JavaScript bundle is ready.

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,6 +437,7 @@ function webpackPluginServe({
             await next();
           }),
         static: staticPaths,
+        waitForBuild: true,
         ...options,
       }),
     ],


### PR DESCRIPTION
---
Closes #37
---

**How to test (feature)**

**How to test (potential regressions)**
